### PR TITLE
Add `SMBDirEntry` to exposed symbols

### DIFF
--- a/smbclient/__init__.py
+++ b/smbclient/__init__.py
@@ -44,6 +44,7 @@ from smbclient._os import (
     listxattr,
     removexattr,
     setxattr,
+    SMBDirEntry,
     SMBStatResult,
     SMBStatVolumeResult,
     XATTR_CREATE,


### PR DESCRIPTION
Objects of this type are returned by the `scandir` generator.